### PR TITLE
Revert "build(deps): bump prost from 0.8.0 to 0.9.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8894a4cb9b32a73030f2c2dd6a251114d5ec62fb786d011850ae98cdfb8d2ff2"
 dependencies = [
- "prost 0.8.0",
+ "prost",
  "prost-types",
  "tonic",
 ]
@@ -1020,17 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1045,7 +1035,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.8.0",
+ "prost",
  "prost-types",
  "tempfile",
  "which",
@@ -1065,26 +1055,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -1406,7 +1383,7 @@ dependencies = [
  "gcp_auth",
  "googapis",
  "http",
- "prost 0.9.0",
+ "prost",
  "prost-types",
  "reqwest",
  "serde_json",
@@ -1634,8 +1611,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.8.0",
- "prost-derive 0.8.0",
+ "prost",
+ "prost-derive",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -1654,7 +1631,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "988af45de0c4480772a9418d79e8b3819797fbeb1e9a2aeb3ba05b43c03b1e8a"
 dependencies = [
- "prost 0.8.0",
+ "prost",
  "prost-build",
  "prost-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dyn-clone = "1.0"
 gcp_auth = "0.5"
 googapis = { version = "0.5", features = ["google-spanner-v1"] }
 http = "0.2"
-prost = "0.9"
+prost = "0.8"
 prost-types = "0.8"
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"


### PR DESCRIPTION
Reverts plaflamme/spanner-rs#7

Need to upgrade `prost-types` which depends on `googapis` which depends on `tonic-build`